### PR TITLE
Readme tweak: Open Street Maps -> OpenStreetMap

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Scroll down for english description, please**
 
-shMapper - это плагин для WordPress. shMapper позволяет создавать простые краудсорсинговые карты на OpenStreet Maps с опцией формы обратной связи. Этот плагин предоставляет вам альтернативу текущим картографическим сервисам, таким как Яндекс.Карты, Карты Google и т.д., которые не предоставляют пользователям возможность добавлять новые объекты.
+shMapper - это плагин для WordPress. shMapper позволяет создавать простые краудсорсинговые карты на OpenStreetMap с опцией формы обратной связи. Этот плагин предоставляет вам альтернативу текущим картографическим сервисам, таким как Яндекс.Карты, Карты Google и т.д., которые не предоставляют пользователям возможность добавлять новые объекты.
 
 Плагин разработан и поддерживается [Теплицей социальных технологий](//te-st.ru/).
 
@@ -41,7 +41,7 @@ shMapper - это плагин для WordPress. shMapper позволяет с�
 
 ## In English ##
 
-shMapper is a WordPress plugin. The shMapper allows you to create simple crowdsourcing maps on OpenStreet Maps with an option of feedback messages form. This plugin gives you an alternative to current online map services such as Yandex.Maps, Google Maps etc which don’t provide the option for users to add new objects.
+shMapper is a WordPress plugin. The shMapper allows you to create simple crowdsourcing maps on OpenStreetMap with an option of feedback messages form. This plugin gives you an alternative to current online map services such as Yandex.Maps, Google Maps etc which don’t provide the option for users to add new objects.
 
 This plugin developed and supported by [Teplitsa of social technologies](//te-st.ru/).
 

--- a/README.txt
+++ b/README.txt
@@ -2,7 +2,7 @@
 Contributors: Genagl, denis.cherniatev
 Author URI: http://te-st.ru
 Plugin URI: http://genagl.ru/?p=652
-Tags: map, Open Street Maps, OSM, yandex.map, crowdsourcing, карта, yandex.карты
+Tags: map, OpenStreetMap, OSM, yandex.map, crowdsourcing, карта, yandex.карты
 Requires at least: 3.6.1
 Tested up to: 5.2
 Requires PHP: 5.6
@@ -10,11 +10,11 @@ Stable tag: trunk
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
-shMapper is a plugin, that allows you to create simple crowdsourcing maps based on Open Street Maps and Yandex.Maps.
+shMapper is a plugin, that allows you to create simple crowdsourcing maps based on OpenStreetMap and Yandex.Maps.
 
 == Description ==
 
-The shMapper plugin allows you to create simple crowdsourcing maps on OpenStreet Maps with an option of feedback messages form. This plugin gives you an alternative to current online map services such as Yandex.Maps, Google Maps etc which don’t provide the option for users to add new objects.
+The shMapper plugin allows you to create simple crowdsourcing maps on OpenStreetMap with an option of feedback messages form. This plugin gives you an alternative to current online map services such as Yandex.Maps, Google Maps etc which don’t provide the option for users to add new objects.
 
 **Core features**
 


### PR DESCRIPTION
The correct way to write it is "OpenStreetMap" singular